### PR TITLE
Use interface descriptions instead of hardware names where possible.

### DIFF
--- a/pfsense_zbx.php
+++ b/pfsense_zbx.php
@@ -57,16 +57,38 @@ function pfz_test(){
 
 
 function pfz_get_if_name($hwif){
-    
-     $ifdescrs = get_configured_interface_with_descr(true); 
-     foreach ($ifdescrs as $ifdescr => $ifname){	     
+
+     $ifdescrs = get_configured_interface_with_descr(true);
+     foreach ($ifdescrs as $ifdescr => $ifname){
           $ifinfo = get_interface_info($ifdescr);
           if($ifinfo["hwif"]==$hwif){
-               echo $ifname;
-               return true;          
+               return $ifname;
           }
      }
-    
+     return null;
+
+}
+
+//Interface Discovery
+function pfz_interface_discovery() {
+    $ifaces = get_interface_arr();
+
+    $json_string = '{"data":[';
+
+    foreach ($ifaces as $iface) {
+        $json_string .= '{"{#IFNAME}":"' . $iface . '"';
+
+        $descr = pfz_get_if_name($iface);
+        if($descr === null){ $descr = $iface; }
+
+        $json_string .= ',"{#IFDESCR}":"' . $descr . '"';
+        $json_string .= '},';
+    }
+    $json_string = rtrim($json_string,",");
+    $json_string .= "]}";
+
+    echo $json_string;
+
 }
 
 
@@ -323,6 +345,9 @@ function pfz_discovery($section){
                break;
           case "services":
                pfz_services_discovery();
+               break;
+          case "interfaces":
+               pfz_interface_discovery();
                break;
      }         
 }

--- a/template_pfsense_active.xml
+++ b/template_pfsense_active.xml
@@ -2980,7 +2980,7 @@
                     <type>7</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>net.if.discovery</key>
+                    <key>pfsense.discovery[interfaces]</key>
                     <delay>3600</delay>
                     <status>0</status>
                     <allowed_hosts/>
@@ -3015,7 +3015,7 @@
                     <description>Discovery of network interfaces as defined in global regular expression &quot;Network interfaces for discovery&quot;.</description>
                     <item_prototypes>
                         <item_prototype>
-                            <name>Incoming network traffic on $1</name>
+                            <name>Incoming network traffic on {#IFDESCR}</name>
                             <type>7</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -3084,7 +3084,7 @@
                             <master_item/>
                         </item_prototype>
                         <item_prototype>
-                            <name>Outgoing network traffic on $1</name>
+                            <name>Outgoing network traffic on {#IFDESCR}</name>
                             <type>7</type>
                             <snmp_community/>
                             <snmp_oid/>
@@ -3156,7 +3156,7 @@
                     <trigger_prototypes/>
                     <graph_prototypes>
                         <graph_prototype>
-                            <name>Network traffic on {#IFNAME}</name>
+                            <name>Network traffic on {#IFDESCR}</name>
                             <width>900</width>
                             <height>200</height>
                             <yaxismin>0.0000</yaxismin>


### PR DESCRIPTION
Adds a custom discovery that uses interface descriptions (eg. WAN, LAN, Office) instead of hardware names when one is available.