### PR TITLE
Client status map key correction

### DIFF
--- a/pfsense_zbx.php
+++ b/pfsense_zbx.php
@@ -240,7 +240,7 @@ function pfz_openvpn_clientvalue($client_id, $valuekey){
      switch ($valuekey){        
                
           case "status":
-               $value = pfz_valuemap("openvpn.server.client", $value);
+               $value = pfz_valuemap("openvpn.client.status", $value);
                break;
 
      }


### PR DESCRIPTION
This is what I was referring at #21 
Please take a look, and let me know if it is indeed needed.
My tests showed, that the "openvpn.server.client" key is not used anywhere else, so it always returns 0