### PR TITLE
Certificates and services monitoring 

### DIFF
--- a/pfsense_zbx.php
+++ b/pfsense_zbx.php
@@ -1069,6 +1069,29 @@ function pfz_get_smart_status(){
 	echo $status;
 }
 
+// Certificats validity date
+function pfz_get_cert_date($valuekey){
+    global $config;
+    
+    $value = 0;
+	foreach (array("cert", "ca") as $cert_type) {
+		switch ($valuekey){
+		case "validFrom.max":
+			foreach ($config[$cert_type] as $cert) {
+				$certinfo = openssl_x509_parse(base64_decode($cert[crt]));
+				if ($value == 0 or $value < $certinfo['validFrom_time_t']) $value = $certinfo['validFrom_time_t'];
+            }
+			break;
+		case "validTo.min":
+			foreach ($config[$cert_type] as $cert) {
+				$certinfo = openssl_x509_parse(base64_decode($cert[crt]));
+				if ($value == 0 or $value > $certinfo['validTo_time_t']) $value = $certinfo['validTo_time_t'];
+			}
+			break;
+		}
+	}
+	echo $value;
+}
 
 // File is present
 function pfz_file_exists($filename) {
@@ -1269,6 +1292,9 @@ switch (strtolower($argv[1])){
      case "smart_status":
           pfz_get_smart_status();
           break;     	  
+     case "cert_date":
+          pfz_get_cert_date($argv[2]);
+          break;
      default:
           pfz_test();
 }

--- a/template_pfsense_active.xml
+++ b/template_pfsense_active.xml
@@ -22,6 +22,9 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
             </groups>
             <applications>
                 <application>
+                    <name>Certificate Manager</name>
+                </application>
+                <application>
                     <name>CPU</name>
                 </application>
                 <application>
@@ -35,9 +38,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                 </application>
                 <application>
                     <name>Memory</name>
-                </application>
-                <application>
-                    <name>Network interfaces</name>
                 </application>
                 <application>
                     <name>Network Limits</name>
@@ -66,8 +66,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Maximum number of opened files</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>kernel.maxfiles</key>
-                    <delay>3600</delay>
-                    <history>27d</history>
+                    <delay>1h</delay>
                     <description>It could be increased by using sysctrl utility or modifying file /etc/sysctl.conf.</description>
                     <applications>
                         <application>
@@ -86,8 +85,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Maximum number of processes</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>kernel.maxproc</key>
-                    <delay>3600</delay>
-                    <history>27d</history>
+                    <delay>1h</delay>
                     <description>It could be increased by using sysctrl utility or modifying file /etc/sysctl.conf.</description>
                     <applications>
                         <application>
@@ -106,8 +104,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Used memory (calc)</name>
                     <type>CALCULATED</type>
                     <key>kt.mem.used</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <units>B</units>
                     <params>last(vm.memory.size[total]) - last(vm.memory.size[available])</params>
                     <applications>
@@ -136,8 +132,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>MBUF Cache</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.mbuf.cache</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <applications>
                         <application>
                             <name>Network Limits</name>
@@ -148,8 +142,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>MBUF Current</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.mbuf.current</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <applications>
                         <application>
                             <name>Network Limits</name>
@@ -160,8 +152,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>MBUF Max</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.mbuf.max</key>
-                    <delay>600</delay>
-                    <history>27d</history>
+                    <delay>10m</delay>
                     <applications>
                         <application>
                             <name>Network Limits</name>
@@ -172,8 +163,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>MBUF Total Used (percent)</name>
                     <type>CALCULATED</type>
                     <key>pfsense.mbuf.ptotal</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <value_type>FLOAT</value_type>
                     <units>%</units>
                     <params>((last(pfsense.mbuf.current) + last(pfsense.mbuf.cache)) * 100) / last(pfsense.mbuf.max)</params>
@@ -199,8 +188,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>States Table Current</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.states.current</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <applications>
                         <application>
                             <name>Network Limits</name>
@@ -211,8 +198,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>States Table Max</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.states.max</key>
-                    <delay>600</delay>
-                    <history>27d</history>
+                    <delay>10m</delay>
                     <applications>
                         <application>
                             <name>Network Limits</name>
@@ -223,8 +209,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>States Table Current (percent)</name>
                     <type>CALCULATED</type>
                     <key>pfsense.states.pused</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <value_type>FLOAT</value_type>
                     <units>%</units>
                     <params>(last(pfsense.states.current) * 100) / last(pfsense.states.max)</params>
@@ -263,7 +247,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <triggers>
                         <trigger>
                             <expression>{last()}&gt;2</expression>
-                            <name>CARP  Problems on {HOST.NAME}</name>
+                            <name>CARP Problems on {HOST.NAME}</name>
                             <priority>HIGH</priority>
                             <description>CARP Problems</description>
                         </trigger>
@@ -277,10 +261,89 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     </triggers>
                 </item>
                 <item>
+                    <name>Certificates Manager: latest &quot;validFrom&quot;</name>
+                    <key>pfsense.value[cert_date,validFrom.max]</key>
+                    <units>unixtime</units>
+                    <description>This item will return will return the latest date &quot;validFrom&quot; from all the certificates (including CA). This is used to find new/renewed certificates.</description>
+                    <applications>
+                        <application>
+                            <name>Certificate Manager</name>
+                        </application>
+                    </applications>
+                    <preprocessing>
+                        <step>
+                            <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                            <params>1d</params>
+                        </step>
+                    </preprocessing>
+                    <triggers>
+                        <trigger>
+                            <expression>({now()}-{last()})&lt;1d</expression>
+                            <name>One or more certificates have been renewed in the past 24h</name>
+                            <opdata>Latest &quot;Valid From&quot;: {ITEM.LASTVALUE1}</opdata>
+                            <priority>INFO</priority>
+                            <manual_close>YES</manual_close>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <name>Certificates Manager: earliest &quot;validTo&quot;</name>
+                    <key>pfsense.value[cert_date,validTo.min]</key>
+                    <units>unixtime</units>
+                    <description>This item will return will return the earliest date &quot;validTo&quot; from all the certificates (including CA). This is used to find expiring certificates.</description>
+                    <applications>
+                        <application>
+                            <name>Certificate Manager</name>
+                        </application>
+                    </applications>
+                    <preprocessing>
+                        <step>
+                            <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                            <params>1d</params>
+                        </step>
+                    </preprocessing>
+                    <triggers>
+                        <trigger>
+                            <expression>{last()}&lt;{now()}</expression>
+                            <name>One or more certificates are expired</name>
+                            <opdata>Earliest &quot;Valid To&quot;: {ITEM.LASTVALUE1}</opdata>
+                            <priority>HIGH</priority>
+                        </trigger>
+                        <trigger>
+                            <expression>({last()}-{now()})&lt;{$PFSENSE_CERT_EXPIRATION.AVERAGE}</expression>
+                            <name>One or more certificates are expiring less than {$PFSENSE_CERT_EXPIRATION.AVERAGE}</name>
+                            <opdata>Earliest &quot;Valid To&quot;: {ITEM.LASTVALUE1}</opdata>
+                            <priority>AVERAGE</priority>
+                            <dependencies>
+                                <dependency>
+                                    <name>One or more certificates are expired</name>
+                                    <expression>{Template pfSense Active:pfsense.value[cert_date,validTo.min].last()}&lt;{Template pfSense Active:pfsense.value[cert_date,validTo.min].now()}</expression>
+                                </dependency>
+                            </dependencies>
+                        </trigger>
+                        <trigger>
+                            <expression>({last()}-{now()})&lt;{$PFSENSE_CERT_EXPIRATION.WARN}</expression>
+                            <name>One or more certificates are expiring less than {$PFSENSE_CERT_EXPIRATION.WARN}</name>
+                            <opdata>Earliest &quot;Valid To&quot;: {ITEM.LASTVALUE1}</opdata>
+                            <priority>WARNING</priority>
+                            <dependencies>
+                                <dependency>
+                                    <name>One or more certificates are expired</name>
+                                    <expression>{Template pfSense Active:pfsense.value[cert_date,validTo.min].last()}&lt;{Template pfSense Active:pfsense.value[cert_date,validTo.min].now()}</expression>
+                                </dependency>
+                                <dependency>
+                                    <name>One or more certificates are expiring less than {$PFSENSE_CERT_EXPIRATION.AVERAGE}</name>
+                                    <expression>({Template pfSense Active:pfsense.value[cert_date,validTo.min].last()}-{Template pfSense Active:pfsense.value[cert_date,validTo.min].now()})&lt;{$PFSENSE_CERT_EXPIRATION.AVERAGE}</expression>
+                                </dependency>
+                            </dependencies>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
                     <name>DHCP Failover Pool Problems</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.value[dhcp,failover]</key>
-                    <delay>120s</delay>
+                    <delay>2m</delay>
                     <description>This value indicates, in a HA scenario, if DHCP failover pool partners are out of sync.</description>
                     <applications>
                         <application>
@@ -292,7 +355,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Gateway Status Raw</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.value[gw_status]</key>
-                    <delay>60s</delay>
                     <trends>0</trends>
                     <value_type>TEXT</value_type>
                     <description>Gateway Status Raw</description>
@@ -317,7 +379,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>SMART Status</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.value[smart_status]</key>
-                    <delay>1800s</delay>
+                    <delay>30m</delay>
                     <description>pfSense SMART Status</description>
                     <applications>
                         <application>
@@ -387,6 +449,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                         <trigger>
                             <expression>{last()}&gt;0</expression>
                             <name>Packages Update Available on {HOST.NAME}</name>
+                            <opdata>{ITEM.LASTVALUE}</opdata>
                             <priority>INFO</priority>
                             <description>New version of packages are available</description>
                         </trigger>
@@ -409,8 +472,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Number of running processes</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>proc.num[,,run]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <description>Number of processes in running state.</description>
                     <applications>
                         <application>
@@ -429,8 +490,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Number of processes</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>proc.num[]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <description>Total number of processes in any state.</description>
                     <applications>
                         <application>
@@ -449,8 +508,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Host boot time</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.boottime</key>
-                    <delay>600</delay>
-                    <history>27d</history>
+                    <delay>10m</delay>
                     <units>unixtime</units>
                     <applications>
                         <application>
@@ -462,8 +520,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Interrupts per second</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.cpu.intr</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <units>ips</units>
                     <applications>
                         <application>
@@ -481,8 +537,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Processor load (1min/core)</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.cpu.load[percpu,avg1]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <value_type>FLOAT</value_type>
                     <description>The processor load is calculated as system CPU load divided by number of CPU cores.</description>
                     <applications>
@@ -502,8 +556,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Processor load (5min/core)</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.cpu.load[percpu,avg5]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <value_type>FLOAT</value_type>
                     <description>The processor load is calculated as system CPU load divided by number of CPU cores.</description>
                     <applications>
@@ -516,8 +568,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Processor load (15min/core)</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.cpu.load[percpu,avg15]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <value_type>FLOAT</value_type>
                     <description>The processor load is calculated as system CPU load divided by number of CPU cores.</description>
                     <applications>
@@ -530,8 +580,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Context switches per second</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.cpu.switches</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <units>sps</units>
                     <applications>
                         <application>
@@ -549,8 +597,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>CPU $2 time</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.cpu.util[,idle]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <value_type>FLOAT</value_type>
                     <units>%</units>
                     <description>The time the CPU has spent doing nothing.</description>
@@ -564,8 +610,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>CPU $2 time</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.cpu.util[,interrupt]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <value_type>FLOAT</value_type>
                     <units>%</units>
                     <description>The amount of time the CPU has been servicing hardware interrupts.</description>
@@ -579,8 +623,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>CPU $2 time</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.cpu.util[,nice]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <value_type>FLOAT</value_type>
                     <units>%</units>
                     <description>The time the CPU has spent running users' processes that have been niced.</description>
@@ -594,8 +636,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>CPU $2 time</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.cpu.util[,system]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <value_type>FLOAT</value_type>
                     <units>%</units>
                     <description>The time the CPU has spent running the kernel and its processes.</description>
@@ -609,8 +649,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>CPU $2 time</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.cpu.util[,user]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <value_type>FLOAT</value_type>
                     <units>%</units>
                     <description>The time the CPU has spent running users' processes that are not niced.</description>
@@ -624,8 +662,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Host name</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.hostname</key>
-                    <delay>3600</delay>
-                    <history>27d</history>
+                    <delay>1h</delay>
                     <trends>0</trends>
                     <value_type>CHAR</value_type>
                     <description>System host name.</description>
@@ -647,8 +684,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Host local time</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.localtime</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <units>unixtime</units>
                     <applications>
                         <application>
@@ -660,8 +695,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Free swap space</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.swap.size[,free]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <units>B</units>
                     <applications>
                         <application>
@@ -673,8 +706,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Free swap space in %</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.swap.size[,pfree]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <value_type>FLOAT</value_type>
                     <units>%</units>
                     <applications>
@@ -695,8 +726,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Total swap space</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.swap.size[,total]</key>
-                    <delay>3600</delay>
-                    <history>27d</history>
+                    <delay>1h</delay>
                     <units>B</units>
                     <applications>
                         <application>
@@ -708,8 +738,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Used swap space</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.swap.size[,used]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <units>B</units>
                     <applications>
                         <application>
@@ -721,8 +749,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>System information</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.uname</key>
-                    <delay>3600</delay>
-                    <history>27d</history>
+                    <delay>1h</delay>
                     <trends>0</trends>
                     <value_type>CHAR</value_type>
                     <description>The information as normally returned by 'uname -a'.</description>
@@ -744,8 +771,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>System uptime</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.uptime</key>
-                    <delay>600</delay>
-                    <history>27d</history>
+                    <delay>10m</delay>
                     <units>uptime</units>
                     <applications>
                         <application>
@@ -764,8 +790,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Number of logged in users</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>system.users.num</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <description>Number of users who are currently logged in.</description>
                     <applications>
                         <application>
@@ -777,8 +801,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Checksum of $1</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vfs.file.cksum[/etc/passwd]</key>
-                    <delay>3600</delay>
-                    <history>27d</history>
+                    <delay>1h</delay>
                     <applications>
                         <application>
                             <name>OS</name>
@@ -796,8 +819,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Active memory</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vm.memory.size[active]</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <units>B</units>
                     <description>Memory used by processes</description>
                     <applications>
@@ -810,8 +831,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Available memory</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vm.memory.size[available]</key>
-                    <delay>60</delay>
-                    <history>27d</history>
                     <units>B</units>
                     <description>Available memory is defined as free+cached+buffers memory.</description>
                     <applications>
@@ -831,8 +850,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Buffered memory</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vm.memory.size[buffers]</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <status>DISABLED</status>
                     <units>B</units>
                     <description>Cache d'entrées des IO disque.&#13;
@@ -848,8 +865,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Cached memory</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vm.memory.size[cached]</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <units>B</units>
                     <description>amount of memory used to cache data</description>
                     <applications>
@@ -862,8 +877,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Free memory</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vm.memory.size[free]</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <units>B</units>
                     <description>amount of memory completely free and ready to be used directly.</description>
                     <applications>
@@ -876,8 +889,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Inactive memory</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vm.memory.size[inactive]</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <units>B</units>
                     <description>amount of memory that contains data that is no longer used (can be directly freed if needed)</description>
                     <applications>
@@ -890,8 +901,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Available memory (percent)</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vm.memory.size[pavailable]</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <value_type>FLOAT</value_type>
                     <units>%</units>
                     <description>Available memory is defined as free+cached+buffers memory.</description>
@@ -911,8 +920,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Shared memory</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vm.memory.size[shared]</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <status>DISABLED</status>
                     <units>B</units>
                     <description>quantité de mémoire partagée entre plusieurs processus&#13;
@@ -928,8 +935,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Total memory</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vm.memory.size[total]</key>
-                    <delay>3600</delay>
-                    <history>27d</history>
+                    <delay>1h</delay>
                     <units>B</units>
                     <description>quantité de mémoire totale</description>
                     <applications>
@@ -942,8 +948,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Used memory</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vm.memory.size[used]</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <status>DISABLED</status>
                     <units>B</units>
                     <description>Item désactivé car non utilisé</description>
@@ -957,8 +961,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Wired memory</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vm.memory.size[wired]</key>
-                    <delay>60</delay>
-                    <history>28d</history>
                     <units>B</units>
                     <description>amount of memory used by the kernel, can neither be unloaded in swap, nor compressed.</description>
                     <applications>
@@ -973,7 +975,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Gateways Discovery</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.discovery[gw]</key>
-                    <delay>300s</delay>
+                    <delay>5m</delay>
                     <description>Gateway Discovery</description>
                     <item_prototypes>
                         <item_prototype>
@@ -1125,7 +1127,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Network interface discovery</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.discovery[interfaces]</key>
-                    <delay>3600s</delay>
+                    <delay>1h</delay>
                     <filter>
                         <conditions>
                             <condition>
@@ -1142,7 +1144,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>Incoming Errors on {#IFDESCR}</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>net.if.in[{#IFNAME},errors]</key>
-                            <delay>60</delay>
                             <history>7d</history>
                             <applications>
                                 <application>
@@ -1154,7 +1155,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>Incoming network traffic on {#IFDESCR}</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>net.if.in[{#IFNAME}]</key>
-                            <delay>60</delay>
                             <history>7d</history>
                             <units>bps</units>
                             <applications>
@@ -1177,7 +1177,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>Outgoing errors on {#IFDESCR}</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>net.if.out[{#IFNAME},errors]</key>
-                            <delay>60</delay>
                             <history>7d</history>
                             <applications>
                                 <application>
@@ -1189,7 +1188,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>Outgoing network traffic on {#IFDESCR}</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>net.if.out[{#IFNAME}]</key>
-                            <delay>60</delay>
                             <history>7d</history>
                             <units>bps</units>
                             <applications>
@@ -1241,14 +1239,13 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>OpenVPN Client Discovery</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.discovery[openvpn_client]</key>
-                    <delay>300s</delay>
+                    <delay>5m</delay>
                     <description>OpenVPN Client Discovery</description>
                     <item_prototypes>
                         <item_prototype>
                             <name>OpenVPN Client  {#NAME} Tunnel Status</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_clientvalue,{#CLIENT},status]</key>
-                            <delay>60s</delay>
                             <applications>
                                 <application>
                                     <name>OpenVPN Client</name>
@@ -1272,13 +1269,12 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>OpenVPN Server Discovery</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.discovery[openvpn_server]</key>
-                    <delay>300s</delay>
+                    <delay>5m</delay>
                     <item_prototypes>
                         <item_prototype>
                             <name>OpenVPN Server {#NAME} Clients Connected</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_servervalue,{#SERVER},conns]</key>
-                            <delay>60s</delay>
                             <applications>
                                 <application>
                                     <name>OpenVPN Server</name>
@@ -1289,7 +1285,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>OpenVPN Server {#NAME} Mode</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_servervalue,{#SERVER},mode]</key>
-                            <delay>300s</delay>
+                            <delay>5m</delay>
                             <applications>
                                 <application>
                                     <name>OpenVPN Server</name>
@@ -1303,7 +1299,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>OpenVPN Server {#NAME} Port</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_servervalue,{#SERVER},port]</key>
-                            <delay>300s</delay>
+                            <delay>5m</delay>
                             <applications>
                                 <application>
                                     <name>OpenVPN Server</name>
@@ -1314,8 +1310,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>OpenVPN Server {#NAME} Tunnel Status</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_servervalue,{#SERVER},status]</key>
-                            <delay>60s</delay>
-                            <applications>
+                                    <applications>
                                 <application>
                                     <name>OpenVPN Server</name>
                                 </application>
@@ -1338,7 +1333,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Services Discovery</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.discovery[services]</key>
-                    <delay>300s</delay>
+                    <delay>5m</delay>
                     <filter>
                         <conditions>
                             <condition>
@@ -1350,10 +1345,10 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     </filter>
                     <item_prototypes>
                         <item_prototype>
-                            <name>Service {#DESCRIPTION}  enabled on CARP Slave</name>
+                            <name>Service {#DESCRIPTION} enabled on CARP Slave</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[service_value,{#SERVICE},run_on_carp_slave]</key>
-                            <delay>600s</delay>
+                            <delay>10m</delay>
                             <applications>
                                 <application>
                                     <name>Services</name>
@@ -1367,7 +1362,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>Service {#DESCRIPTION} Status</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[service_value,{#SERVICE},status]</key>
-                            <delay>60s</delay>
                             <applications>
                                 <application>
                                     <name>Services</name>
@@ -1380,7 +1374,8 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{Template pfSense Active:pfsense.value[service_value,{#SERVICE},status].last()}=0 and (&#13;
+                            <expression>{Template pfSense Active:pfsense.value[service_value,{#SERVICE},status].last()}=0 &#13;
+and {$PFSENSE_SRVC_MONITORING:&quot;{#SERVICE}&quot;}=1 and (&#13;
 &#13;
 ({Template pfSense Active:pfsense.value[service_value,{#SERVICE},run_on_carp_slave].last()}=1 and &#13;
 {Template pfSense Active:pfsense.value[carp_status].last()}=2)&#13;
@@ -1395,7 +1390,26 @@ or&#13;
 )</expression>
                             <name>Service {#DESCRIPTION} is not running</name>
                             <priority>HIGH</priority>
-                            <description>Service is not running</description>
+                            <description>Service is not running&#13;
+&#13;
+If you want to skip the trigger for this service, add the macro $PFSENSE_SRVC_MONITORING:&quot;{#SERVICE}&quot;=0&#13;
+&#13;
+0 = Service monitoring disabled&#13;
+1 = Service monitoring check if running&#13;
+2 = Service monitoring check if not running</description>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <expression>{Template pfSense Active:pfsense.value[service_value,{#SERVICE},status].last()}=1 and {$PFSENSE_SRVC_MONITORING:&quot;{#SERVICE}&quot;}=2 and (({Template pfSense Active:pfsense.value[service_value,{#SERVICE},run_on_carp_slave].last()}=1 and {Template pfSense Active:pfsense.value[carp_status].last()}=2) or {Template pfSense Active:pfsense.value[carp_status].last()}=1 or {Template pfSense Active:pfsense.value[carp_status].last()}=0)</expression>
+                            <name>Service {#DESCRIPTION} is running</name>
+                            <priority>HIGH</priority>
+                            <description>Service is running&#13;
+&#13;
+If you want to skip the trigger for this service, remove the macro $PFSENSE_SRVC_MONITORING:&quot;{#SERVICE}&quot;=2&#13;
+Alternatively you can also set the macro to 1 or 0.&#13;
+&#13;
+0 = Service monitoring disabled&#13;
+1 = Service monitoring check if running&#13;
+2 = Service monitoring check if not running</description>
                         </trigger_prototype>
                     </trigger_prototypes>
                 </discovery_rule>
@@ -1403,7 +1417,7 @@ or&#13;
                     <name>Mounted filesystem discovery</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>vfs.fs.discovery</key>
-                    <delay>3600</delay>
+                    <delay>1h</delay>
                     <filter>
                         <conditions>
                             <condition>
@@ -1420,7 +1434,6 @@ or&#13;
                             <name>Free inodes on $1 (percentage)</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>vfs.fs.inode[{#FSNAME},pfree]</key>
-                            <delay>60</delay>
                             <history>7d</history>
                             <value_type>FLOAT</value_type>
                             <units>%</units>
@@ -1441,7 +1454,6 @@ or&#13;
                             <name>Free disk space on $1</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>vfs.fs.size[{#FSNAME},free]</key>
-                            <delay>60</delay>
                             <history>7d</history>
                             <units>B</units>
                             <applications>
@@ -1454,7 +1466,6 @@ or&#13;
                             <name>Free disk space on $1 (percentage)</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>vfs.fs.size[{#FSNAME},pfree]</key>
-                            <delay>60</delay>
                             <history>7d</history>
                             <value_type>FLOAT</value_type>
                             <units>%</units>
@@ -1475,7 +1486,7 @@ or&#13;
                             <name>Total disk space on $1</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>vfs.fs.size[{#FSNAME},total]</key>
-                            <delay>3600</delay>
+                            <delay>1h</delay>
                             <history>7d</history>
                             <units>B</units>
                             <applications>
@@ -1488,7 +1499,6 @@ or&#13;
                             <name>Used disk space on $1</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>vfs.fs.size[{#FSNAME},used]</key>
-                            <delay>60</delay>
                             <history>7d</history>
                             <units>B</units>
                             <applications>
@@ -1554,6 +1564,29 @@ or&#13;
                 <macro>
                     <macro>{$EXPECTED_CARP_STATUS}</macro>
                     <value>0</value>
+                </macro>
+                <macro>
+                    <macro>{$PFSENSE_CERT_EXPIRATION.AVERAGE}</macro>
+                    <value>48h</value>
+                </macro>
+                <macro>
+                    <macro>{$PFSENSE_CERT_EXPIRATION.WARN}</macro>
+                    <value>10d</value>
+                </macro>
+                <macro>
+                    <macro>{$PFSENSE_SRVC_MONITORING}</macro>
+                    <value>1</value>
+                    <description>Enable monitoring of Services</description>
+                </macro>
+                <macro>
+                    <macro>{$PFSENSE_SRVC_MONITORING:&quot;iperf&quot;}</macro>
+                    <value>0</value>
+                    <description>Disable monitoring of Service iperf Network Performance Testing Daemon/Client</description>
+                </macro>
+                <macro>
+                    <macro>{$PFSENSE_SRVC_MONITORING:&quot;pcscd&quot;}</macro>
+                    <value>2</value>
+                    <description>Enable monitoring of PC/SC Smart Card Daemon (check if NOT running) https://redmine.pfsense.org/issues/12095</description>
                 </macro>
             </macros>
             <screens>
@@ -1666,7 +1699,7 @@ or&#13;
             <expression>({Template pfSense Active:pfsense.value[system,version].last()}&lt;&gt;{Template pfSense Active:pfsense.value[system,installed_version].last()})=1</expression>
             <name>New Version Available on {HOST.NAME}</name>
             <priority>INFO</priority>
-            <description>Noify of new version of pfsense available</description>
+            <description>Notify of new version of pfsense available</description>
         </trigger>
     </triggers>
     <graphs>

--- a/template_pfsense_active.xml
+++ b/template_pfsense_active.xml
@@ -262,6 +262,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                 </item>
                 <item>
                     <name>Certificates Manager: latest &quot;validFrom&quot;</name>
+                    <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.value[cert_date,validFrom.max]</key>
                     <units>unixtime</units>
                     <description>This item will return will return the latest date &quot;validFrom&quot; from all the certificates (including CA). This is used to find new/renewed certificates.</description>
@@ -288,6 +289,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                 </item>
                 <item>
                     <name>Certificates Manager: earliest &quot;validTo&quot;</name>
+                    <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.value[cert_date,validTo.min]</key>
                     <units>unixtime</units>
                     <description>This item will return will return the earliest date &quot;validTo&quot; from all the certificates (including CA). This is used to find expiring certificates.</description>

--- a/template_pfsense_active.xml
+++ b/template_pfsense_active.xml
@@ -1334,15 +1334,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.discovery[services]</key>
                     <delay>5m</delay>
-                    <filter>
-                        <conditions>
-                            <condition>
-                                <macro>{#SERVICE}</macro>
-                                <value>@pfSense service names for discovery</value>
-                                <formulaid>A</formulaid>
-                            </condition>
-                        </conditions>
-                    </filter>
                     <item_prototypes>
                         <item_prototype>
                             <name>Service {#DESCRIPTION} enabled on CARP Slave</name>

--- a/template_pfsense_active_ipsec.xml
+++ b/template_pfsense_active_ipsec.xml
@@ -33,14 +33,14 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>IPsec Phase 1 Discovery</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.discovery[ipsec_ph1]</key>
-                    <delay>1200s</delay>
+                    <delay>20m</delay>
                     <description>Discovery of IPsec Phase 1</description>
                     <item_prototypes>
                         <item_prototype>
                             <name>IPsec Tunnel {#IKEID} {#NAME} Tunnel Enabled</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[ipsec_ph1,{#IKEID},disabled]</key>
-                            <delay>120s</delay>
+                            <delay>2m</delay>
                             <description>IPsec Phase 1  Tunnel Mode</description>
                             <applications>
                                 <application>
@@ -55,7 +55,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>IPsec Tunnel {#IKEID} {#NAME} IKE Type</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[ipsec_ph1,{#IKEID},iketype]</key>
-                            <delay>600s</delay>
+                            <delay>10m</delay>
                             <description>IPsec Phase 1 IKE Type</description>
                             <applications>
                                 <application>
@@ -70,7 +70,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>IPsec Tunnel {#IKEID} {#NAME} Tunnel Mode</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[ipsec_ph1,{#IKEID},mode]</key>
-                            <delay>600s</delay>
+                            <delay>10m</delay>
                             <description>IPsec Phase 1  Tunnel Mode</description>
                             <applications>
                                 <application>
@@ -85,7 +85,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>IPsec Tunnel {#IKEID} {#NAME} Protocol</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[ipsec_ph1,{#IKEID},protocol]</key>
-                            <delay>600s</delay>
+                            <delay>10m</delay>
                             <description>IPsec Phase 1 Protocol</description>
                             <applications>
                                 <application>
@@ -100,7 +100,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>IPsec Tunnel {#IKEID} {#NAME}  Remote Gateway</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[ipsec_ph1,{#IKEID},remote-gateway]</key>
-                            <delay>600s</delay>
+                            <delay>10m</delay>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
                             <description>IPsec Phase 1  Remote Gateway</description>
@@ -114,7 +114,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>IPsec Tunnel {#IKEID} {#NAME}  Phase 1 Status</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[ipsec_ph1,{#IKEID},status]</key>
-                            <delay>60s</delay>
                             <description>IPsec Phase 1  Tunnel Mode</description>
                             <applications>
                                 <application>
@@ -139,14 +138,14 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>IPsec Phase 2 Discovery</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.discovery[ipsec_ph2]</key>
-                    <delay>1200s</delay>
+                    <delay>20m</delay>
                     <description>Discovery of IPsec Phase 2</description>
                     <item_prototypes>
                         <item_prototype>
                             <name>IPsec Tunnel  {#IKEID}.{#REQID} {#NAME} Phase 2 Enabled</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[ipsec_ph2,{#UNIQID},disabled]</key>
-                            <delay>120s</delay>
+                            <delay>2m</delay>
                             <description>IPsec Tunnel Phase 2 Protocol</description>
                             <applications>
                                 <application>
@@ -161,7 +160,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>IPsec Tunnel  {#IKEID}.{#REQID} {#NAME} Phase 2 Life Time</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[ipsec_ph2,{#UNIQID},lifetime]</key>
-                            <delay>600s</delay>
+                            <delay>10m</delay>
                             <units>s</units>
                             <description>IPsec Tunnel Phase 2 Life Time</description>
                             <applications>
@@ -174,7 +173,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>IPsec Tunnel  {#IKEID}.{#REQID} {#NAME} Phase 2 Mode</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[ipsec_ph2,{#UNIQID},mode]</key>
-                            <delay>600s</delay>
+                            <delay>10m</delay>
                             <description>IPsec Tunnel Phase 2 Mode</description>
                             <applications>
                                 <application>
@@ -186,7 +185,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>IPsec Tunnel  {#IKEID}.{#REQID} {#NAME} Phase 2 Protocol</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[ipsec_ph2,{#UNIQID},protocol]</key>
-                            <delay>600s</delay>
+                            <delay>10m</delay>
                             <description>IPsec Tunnel Phase 2 Protocol</description>
                             <applications>
                                 <application>

--- a/template_pfsense_active_ovpn_user.xml
+++ b/template_pfsense_active_ovpn_user.xml
@@ -33,14 +33,12 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>OpenVPN User Auth Connected Clients Discovery</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.discovery[openvpn_server_user]</key>
-                    <delay>60s</delay>
                     <description>Discovery of clients connected to OpenVPN Server in User Auth Mode</description>
                     <item_prototypes>
                         <item_prototype>
                             <name>OpenVPN Server {#SERVERNAME}, Client {#USERID}: Bytes Received</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_server_uservalue,{#UNIQUEID},bytes_recv]</key>
-                            <delay>60s</delay>
                             <trends>0</trends>
                             <units>bytes</units>
                             <description>Client Bytes Received</description>
@@ -54,7 +52,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>OpenVPN Server {#SERVERNAME}, Client {#USERID}: Bytes Sent</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_server_uservalue,{#UNIQUEID},bytes_sent]</key>
-                            <delay>60s</delay>
                             <trends>0</trends>
                             <units>bytes</units>
                             <description>Client Bytes Sent</description>
@@ -68,7 +65,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>OpenVPN Server {#SERVERNAME}, Client {#USERID}: Connection Time</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_server_uservalue,{#UNIQUEID},connect_time_unix]</key>
-                            <delay>60s</delay>
                             <trends>0</trends>
                             <units>unixtime</units>
                             <description>Client Connect Time</description>
@@ -82,7 +78,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>OpenVPN Server {#SERVERNAME}, Client {#USERID}: Remote Host</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_server_uservalue,{#UNIQUEID},remote_host]</key>
-                            <delay>60s</delay>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
                             <description>Remote Host</description>
@@ -96,7 +91,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>OpenVPN Server {#SERVERNAME}, Client {#USERID}: User Name</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_server_uservalue,{#UNIQUEID},user_name]</key>
-                            <delay>60s</delay>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
                             <description>Client User Name</description>
@@ -110,7 +104,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>OpenVPN Server {#SERVERNAME}, Client {#USERID}: Virtual IP Address (IPv6)</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_server_uservalue,{#UNIQUEID},virtual_addr6]</key>
-                            <delay>60s</delay>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
                             <description>IPv6 Address assigned from OpenVPN Server</description>
@@ -124,7 +117,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>OpenVPN Server {#SERVERNAME}, Client {#USERID}: Virtual IP Address</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_server_uservalue,{#UNIQUEID},virtual_addr]</key>
-                            <delay>60s</delay>
                             <trends>0</trends>
                             <value_type>TEXT</value_type>
                             <description>IP Address assigned from OpenVPN Server</description>
@@ -138,7 +130,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>OpenVPN Server {#SERVERNAME}, Client {#USERID}: Client ID</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_server_uservalue_numeric,{#UNIQUEID},client_id]</key>
-                            <delay>60s</delay>
                             <trends>0</trends>
                             <description>Client ID</description>
                             <applications>
@@ -151,7 +142,6 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>OpenVPN Server {#SERVERNAME}, Client {#USERID}: Peer ID</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[openvpn_server_uservalue_numeric,{#UNIQUEID},peer_id]</key>
-                            <delay>60s</delay>
                             <trends>0</trends>
                             <description>Peer ID</description>
                             <applications>

--- a/template_pfsense_active_speedtest.xml
+++ b/template_pfsense_active_speedtest.xml
@@ -33,14 +33,14 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>WAN Interfaces</name>
                     <type>ZABBIX_ACTIVE</type>
                     <key>pfsense.discovery[wan]</key>
-                    <delay>300s</delay>
+                    <delay>6h</delay>
                     <description>Discover WAN Interfaces</description>
                     <item_prototypes>
                         <item_prototype>
                             <name>Speedtest Download on {#IFDESCR}</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[if_speedtest_value,{#IFNAME},download]</key>
-                            <delay>3600s</delay>
+                            <delay>30m</delay>
                             <value_type>FLOAT</value_type>
                             <units>bps</units>
                             <description>Download speed determined by Ookla Speedtest package</description>
@@ -54,7 +54,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>Speedtest Ping on {#IFDESCR}</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[if_speedtest_value,{#IFNAME},ping]</key>
-                            <delay>3600s</delay>
+                            <delay>30m</delay>
                             <value_type>FLOAT</value_type>
                             <units>ms</units>
                             <description>Ping determined by Ookla Speedtest package</description>
@@ -68,7 +68,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <name>Speedtest Upload on {#IFDESCR}</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[if_speedtest_value,{#IFNAME},upload]</key>
-                            <delay>3600s</delay>
+                            <delay>30m</delay>
                             <value_type>FLOAT</value_type>
                             <units>bps</units>
                             <description>Ping determined by Ookla Speedtest package</description>


### PR DESCRIPTION
- added certificate monitoring #98
- added services monitoring selection based on macro with some default macro #93
    - for iperf service (disabling monitoring) 
    - PC/SC Smart Card Daemon (check if NOT running) because of a memory leak issue.
- removed use of global regex to filter services to monitor 
- removed delay definitions of 60s which should be the default value defined in Zabbix server
- removed history definitions of 27d which should be the default value defined in Zabbix server
- convert a few value to more human-readable form (exemple 3600 to 1h)