### PR TITLE
Add "Network Interfaces" application

### DIFF
--- a/template_pfsense_active.xml
+++ b/template_pfsense_active.xml
@@ -40,6 +40,9 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                     <name>Memory</name>
                 </application>
                 <application>
+                    <name>Network Interfaces</name>
+                </application>
+                <application>
                     <name>Network Limits</name>
                 </application>
                 <application>
@@ -1149,7 +1152,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <history>7d</history>
                             <applications>
                                 <application>
-                                    <name>Network interfaces</name>
+                                    <name>Network Interfaces</name>
                                 </application>
                             </applications>
                         </item_prototype>
@@ -1161,7 +1164,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <units>bps</units>
                             <applications>
                                 <application>
-                                    <name>Network interfaces</name>
+                                    <name>Network Interfaces</name>
                                 </application>
                             </applications>
                             <preprocessing>
@@ -1182,7 +1185,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <history>7d</history>
                             <applications>
                                 <application>
-                                    <name>Network interfaces</name>
+                                    <name>Network Interfaces</name>
                                 </application>
                             </applications>
                         </item_prototype>
@@ -1194,7 +1197,7 @@ https://github.com/rbicelli/pfsense-zabbix-template</description>
                             <units>bps</units>
                             <applications>
                                 <application>
-                                    <name>Network interfaces</name>
+                                    <name>Network Interfaces</name>
                                 </application>
                             </applications>
                             <preprocessing>


### PR DESCRIPTION
# Behavior seen
When importing `template_pfsense_active.xml` into Zabbix 5.0.12 an error is thrown:
>application with ID "" is not available on "pfsense Active". 

# Behavior expected
When I import the unaltered `template_pfsense_active.xml` into Zabbix 5.0.12 with all the default checkboxes I expect it to succeed without any errors and show up in the list of templates.

# Cause and fix
The "Network Interfaces" `application` that is required by the "Network Interface" `discovery` rule is missing. By adding the "Network Interfaces" `application` the problem is solved.
