### PR TITLE
fix: ipsec tunnel status invalid on some versions

### DIFF
--- a/pfsense_zbx.php
+++ b/pfsense_zbx.php
@@ -670,11 +670,12 @@ function pfz_ipsec_status($ikeid,$reqid=-1,$valuekey='state'){
             } else {
                 $cname = "con{$ph1ent['ikeid']}00000";
             }
-            $conmap[$cname] = $ph1ent['ikeid'];
         } else{
             $cname = ipsec_conid($ph1ent);
         }
-	}
+        
+        $conmap[$cname] = $ph1ent['ikeid'];
+    }
 
 	$status = ipsec_list_sa();
 	$ipsecconnected = array();


### PR DESCRIPTION
The status of IPsec status isn't returned correctly on pfSense 22.05 and probably other versions as well due to a dictionary not being updated correctly when the function `get_ipsecifnum` is not available.