### PR TITLE
Fix broken variable initializations php 8.1

### DIFF
--- a/pfsense_zbx.php
+++ b/pfsense_zbx.php
@@ -859,6 +859,13 @@ function pfz_dhcp_get($valuekey) {
 	$leases_count = count($leases_content);
 	@exec("/usr/sbin/arp -an", $rawdata);
 
+	$leases = [];
+	$pools = [];
+	
+	$i = 0;
+	$l = 0;
+	$p = 0;
+
 	foreach ($leases_content as $lease) {
 		/* split the line by space */
 		$data = explode(" ", $lease);


### PR DESCRIPTION
Did not test yet, but expect this to fix:
- https://github.com/rbicelli/pfsense-zabbix-template/issues/138
- https://github.com/rbicelli/pfsense-zabbix-template/issues/135