### PR TITLE
Fix stale "Service SSH Daemon is running" trigger

### DIFF
--- a/pfsense_zbx.php
+++ b/pfsense_zbx.php
@@ -472,31 +472,33 @@ function pfz_service_value($name,$value){
                          $status = get_service_status($service);
                          if ($status=="") $status = 0;
                          echo $status;
-                         break;               
+                         return;
 
                     case "name":
                          echo $namecfr;
-                         break;
+                         return;
 
                     case "enabled":
                          if (is_service_enabled($service['name']))
                               echo 1;
                          else
                               echo 0;
-                         break;
+                         return;
 
                     case "run_on_carp_slave":
                          if (in_array($carpcfr,$stopped_on_carp_slave))
                               echo 0;
                          else
                               echo 1;
-                         break;
+                         return;
                     default:               
                          echo $service[$value];
-                         break;
+                         return;
                }
           }                                              
     }
+
+    echo 0;
 }
 
 


### PR DESCRIPTION
The `Service Secure Shell Daemon is running` trigger is broken: when you turn off the SSH Daemon, the trigger stays active.

This is caused by the `service_value` returning an empty string `""` instead of `0` for _disabled_ services, on which the Zabbix template trips. E.g.:
```bash
/usr/local/bin/php /opt/scripts/pfsense_zbx.php service_value sshd status

# Returns 1 when the daemon is enabled, but "" when it's not. It should return 0 for 
# the Zabbix template to work though.
```

Notice that this problem is not limited to the SSH Daemon, but goes for every other disabled / enabled service.