### PR TITLE
New openvpn status on p2p_shared_key servers

### DIFF
--- a/pfsense_zbx.php
+++ b/pfsense_zbx.php
@@ -1174,6 +1174,7 @@ function pfz_valuemap($valuename, $value, $default="0"){
                     $valuemap = array(
                          "down" => "0",
                          "up" => "1",
+                         "connected (success)" => "1",
                          "none" => "2",
                          "reconnecting; ping-restart" => "3",
                          "waiting" => "4",


### PR DESCRIPTION
After update to 2.7.0 p2p_shared_key servers always returned down.