### PR TITLE
Changes how the system version is tracked from direct to via a cronjob.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ From **Diagnostics/Command Prompt** input this one-liner:
 curl --create-dirs -o /root/scripts/pfsense_zbx.php https://raw.githubusercontent.com/rbicelli/pfsense-zabbix-template/master/pfsense_zbx.php
 ```
 
+Then, setup the system version cronjob with: 
+
+```bash 
+/usr/local/bin/php /root/scripts/pfsense_zbx.php sysversion_cron
+```
 
 Then install package "Zabbix Agent 5" (or "Zabbix Agent 6") on your pfSense Box
 
@@ -99,6 +104,12 @@ For testing if speedtest is installed properly you can try it:
 
 ```bash
 /usr/local/bin/speedtest
+```
+
+Then, setup the cronjob with: 
+
+```bash 
+/url/local/bin/php /root/scripts/pfsense_zbx.php speedtest_cron
 ```
 
 Remember that you will need to install the package on *every* pfSense upgrade.


### PR DESCRIPTION
Add instruction for how to enable this to .md file. Add both cronjobs to disable function.
Add a timeout to stop a stuck function from causing problems.

I had some problems using this on our pfSense hosts: especially those with older hardware couldn't manage to get the version number. Restarting zabbix would get a few days where the version was tracked, but it would timeout afterwards. 

I added it as a cronjob. Because I'm afraid that a long running task might lock up the zabbix system after enough of them hoard all the worker processes, I also added some timeouts to the script. 

This is my first time doing a cross-repo pull request here, so please be kind if there's mistakes in how I set this up.