### PR TITLE
Set the default value for CERT_SECURITY_BITS to 112 for openvpn 2.6+ …

### DIFF
--- a/zabbix5/template_pfsense_active.xml
+++ b/zabbix5/template_pfsense_active.xml
@@ -1532,6 +1532,11 @@ or&#13;
                     <macro>{$EXPECTED_CARP_STATUS}</macro>
                     <value>0</value>
                 </macro>
+                <macro>
+                    <macro>{$CERT_SECURITY_BITS}</macro>
+                    <value>112</value>
+                    <description>Set to 80 for seclevel=0, set to 128 for seclevel=2</description>
+                </macro>
             </macros>
             <screens>
                 <screen>

--- a/zabbix6/pfsense_active.yaml
+++ b/zabbix6/pfsense_active.yaml
@@ -1351,8 +1351,10 @@ zabbix_export:
         -
           macro: '{$CARP_SLAVE_SERVICES:"openvpn"}'
           value: '0'
-        -
-          macro: '{$EXPECTED_CARP_STATUS}'
+        - macro: '{$CERT_SECURITY_BITS}'
+          value: '112'
+          description: 'Set to 80 for seclevel=0, set to 128 for seclevel=2'
+        - macro: '{$EXPECTED_CARP_STATUS}'
           value: '0'
       dashboards:
         -


### PR DESCRIPTION
This macro didn't have a default value so by default the trigger would not complain. It should be changed so you are warned when there are certificates still using SHA1 hashes which will cause VPN connections to fail when users update their OpenVPN client.