### PR TITLE
High Availability gateway trigger fix for site to site VPN

### DIFF
--- a/pfsense_zbx.php
+++ b/pfsense_zbx.php
@@ -17,6 +17,7 @@ require_once('globals.inc');
 require_once('functions.inc');
 require_once('config.inc');
 require_once('util.inc');
+require_once('gwlb.inc');
 
 //For Interfaces Discovery
 require_once('interfaces.inc');
@@ -527,6 +528,13 @@ function pfz_gw_discovery() {
      echo $json_string;
 }
 
+function pfz_gw_config($gw, $valuekey) {
+    $gws = return_gateways_array();
+    if(array_key_exists($gw,$gws)) {
+         $value = $gws[$gw][$valuekey];
+    }
+    echo $value;   
+}
 
 function pfz_gw_value($gw, $valuekey) {
      $gws = return_gateways_status(true);
@@ -1349,6 +1357,9 @@ switch ($mainArgument){
      case "discovery":
           pfz_discovery($argv[2]);
           break;
+     case "gw_config":
+          pfz_gw_config($argv[2],$argv[3]);
+          break;     
      case "gw_value":
           pfz_gw_value($argv[2],$argv[3]);
           break;     

--- a/zabbix5/template_pfsense_active.xml
+++ b/zabbix5/template_pfsense_active.xml
@@ -1043,7 +1043,45 @@ last(/Template pfSense Active/pfsense.value[cert_hash_secbits, {#CERT_INDEX}])&l
                             </preprocessing>
                         </item_prototype>
                         <item_prototype>
-                            <name>Gateway $2 Packet  Loss</name>
+                            <name>Gateway $2 Interface</name>
+                            <type>ZABBIX_ACTIVE</type>
+                            <key>pfsense.value[gw_value,{#GATEWAY},interface]</key>
+                            <delay>0</delay>
+                            <value_type>CHAR</value_type>
+                            <applications>
+                                <application>
+                                    <name>Gateways</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Gateway $2 OpenVPN Server</name>
+                            <type>DEPENDENT</type>
+                            <key>pfsense.value[gw_value,{#GATEWAY},vpnserver]</key>
+                            <delay>0</delay>
+                            <description>VPN server number. 0 if not an OpenVPN interface.</description>
+                            <applications>
+                                <application>
+                                    <name>Gateways</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>REGEX</type>
+                                    <parameters>
+                                        <parameter>ovpns([0-9]+?)</parameter>
+                                        <parameter>\1</parameter>
+                                    </parameters>
+                                    <error_handler>CUSTOM_VALUE</error_handler>
+                                    <error_handler_params>0</error_handler_params>
+                                </step>
+                            </preprocessing>
+                            <master_item>
+                                <key>pfsense.value[gw_config,{#GATEWAY},interface]</key>
+                            </master_item>                            
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Gateway $2 Packet Loss</name>
                             <type>ZABBIX_ACTIVE</type>
                             <key>pfsense.value[gw_value,{#GATEWAY},loss]</key>
                             <delay>60s</delay>
@@ -1094,7 +1132,7 @@ last(/Template pfSense Active/pfsense.value[cert_hash_secbits, {#CERT_INDEX}])&l
                                     <description>Gateway is lagging</description>
                                 </trigger_prototype>
                                 <trigger_prototype>
-                                    <expression>{last()}=3</expression>
+                                    <expression>{last()}=3 and ( last(/Template pfSense Active/pfsense.value[gw_config,{#GATEWAY},vpnserver]) =0 or last(/Template pfSense Active/pfsense.value[carp_status])=1)</expression>
                                     <name>High packet Loss on {#GATEWAY}</name>
                                     <priority>HIGH</priority>
                                     <description>High Packet Loss on Gateway</description>

--- a/zabbix6/pfsense_active.yaml
+++ b/zabbix6/pfsense_active.yaml
@@ -854,6 +854,29 @@ zabbix_export:
           description: 'Gateway Discovery'
           item_prototypes:
             -
+              uuid: 840cd51725f34428a90e15951827a56b
+              name: 'Gateway {#GATEWAY} Interface'
+              type: ZABBIX_ACTIVE
+              key: 'pfsense.value[gw_config,{#GATEWAY},interface]'
+              trends: '0'
+              value_type: CHAR
+            -
+              uuid: a52580ae85f1444cb4d2c713e1cbd2fe
+              name: 'Gateway {#GATEWAY} OpenVPN Server'
+              type: DEPENDENT
+              key: 'pfsense.value[gw_config,{#GATEWAY},vpnserver]'
+              delay: '0'
+              description: 'VPN server number. 0 if not an OpenVPN interface.'
+              preprocessing:
+                - type: REGEX
+                  parameters:
+                    - 'ovpns([0-9]+?)'
+                    - \1
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: 'pfsense.value[gw_config,{#GATEWAY},interface]'
+            -
               uuid: db89e0dd738148e19c52f08bbc7723f7
               name: 'Gateway {#GATEWAY} RTT'
               type: ZABBIX_ACTIVE
@@ -920,7 +943,7 @@ zabbix_export:
                   description: 'Gateway is lagging'
                 -
                   uuid: a89a7d0dbd87432fa13ee7e4d15a4bdf
-                  expression: 'avg(/Template pfSense Active/pfsense.value[gw_value,{#GATEWAY},status],#3)=3'
+                  expression: 'avg(/Template pfSense Active/pfsense.value[gw_value,{#GATEWAY},status],#3)=3 and ( last(/Template pfSense Active/pfsense.value[gw_config,{#GATEWAY},vpnserver]) =0 or last(/Template pfSense Active/pfsense.value[carp_status])=1)'
                   name: 'High packet Loss on {#GATEWAY}'
                   priority: HIGH
                   description: 'High Packet Loss on Gateway'

--- a/zabbix6/pfsense_active.yaml
+++ b/zabbix6/pfsense_active.yaml
@@ -871,7 +871,7 @@ zabbix_export:
                 - tag: Application
                   value: Gateways
             - uuid: ba759ceb73f949108fddbc4029cfc9f2
-              name: 'Gateway {#GATEWAY} Packet  Loss'
+              name: 'Gateway {#GATEWAY} Packet Loss'
               type: ZABBIX_ACTIVE
               key: 'pfsense.value[gw_value,{#GATEWAY},loss]'
               delay: 60s


### PR DESCRIPTION
When high availability is used, the gateway on the CARP slave on an openVPN connection is unreachable. 

The trigger for high packet loss will fire, but this is normal. 

I added the ability for the script to track which connection belongs to which gateway, and an extra condition to this trigger. The trigger will not fire if: 

- The pfSense is in CARP slave mode, 
- The interface's name starts with 'ovpns' (via regex).