### PR TITLE
Update pfsense_zbx.php

### DIFF
--- a/pfsense_zbx.php
+++ b/pfsense_zbx.php
@@ -1152,7 +1152,8 @@ function pfz_get_smart_status(){
 	$status = 0;
 	foreach ($devs as $dev)  { ## for each found drive do                
                 $smartdrive_is_displayed = true;
-                $dev_ident = exec("diskinfo -v /dev/$dev | grep ident   | awk '{print $1}'"); ## get identifier from drive
+                // This does nothing, only beaks the script when you have an NMVE disk
+		//$dev_ident = exec("diskinfo -v /dev/$dev | grep ident   | awk '{print $1}'"); ## get identifier from drive
                 $dev_state = trim(exec("smartctl -H /dev/$dev | awk -F: '/^SMART overall-health self-assessment test result/ {print $2;exit}
 /^SMART Health Status/ {print $2;exit}'")); ## get SMART state from drive
                 switch ($dev_state) {
@@ -1164,12 +1165,12 @@ function pfz_get_smart_status(){
                         case "":
                                 //Unknown
                                 $status=2;
-                                return $status;
+                                //return $status;
                                 break;
                         default:
                         		//Error
                                 $status=1;
-                                return $status;
+                               //return $status;
                                 break;
                 }
 	}


### PR DESCRIPTION
A part of the code breaks  when you have a NVME Disk, Diskinfo cannot get an identified: "diskinfo: /dev/nvme0: ioctl(DIOCGMEDIASIZE) failed, probably not a disk."  Also the $dev_ident is not used here, so can be removed. Also when you have issues on SMART, the state is not correct. Returdn $State gives an String conversion issue. Found out IRL :(