### PR TITLE
update function name to newer version

### DIFF
--- a/pfsense_zbx.php
+++ b/pfsense_zbx.php
@@ -1148,7 +1148,7 @@ function pfz_get_system_value($section){
 // Taken from /usr/local/www/widgets/widgets/smart_status.widget.php
 function pfz_get_smart_status(){
 
-	$devs = get_smart_drive_list();
+	$devs = get_drive_list();
 	$status = 0;
 	foreach ($devs as $dev)  { ## for each found drive do                
                 $smartdrive_is_displayed = true;


### PR DESCRIPTION
In pfSense version 2.8.0, The function `get_smart_drive_list()` was changed to `get_drive_list()`. As a result, `pfsense_zbx.php` throws an error on line 1151 when run on pfSense 2.8.0. I changed the function call to fix this.